### PR TITLE
Generate tag on docker hub for any tag on github

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'main'
     tags:
-      - 'v*.*.*'
+      - '*'
   pull_request:
     branches:
       - 'main'


### PR DESCRIPTION
I saw that the [2.0.1](https://github.com/plone/code-quality/releases/tag/2.0.1) tag was generated on github but a tag was [not generated on the docker hub](https://hub.docker.com/r/plone/code-quality/tags). I think this happened because the tag is only generated in docker hub only if it has a "v" in front of the git tag.

To avoid this, I propose to generate tag in docker hub for all github tags.