### PR TITLE
Generates release only when it has tags in the format `x.y.z`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'main'
     tags:
-      - '*'
+      - '[0-9]+.[0-9]+.[0-9]+'
   pull_request:
     branches:
       - 'main'


### PR DESCRIPTION
Releases were being generated in any push to main.